### PR TITLE
Restore navbar layout/arrow key options to Matrixx Settings

### DIFF
--- a/res/xml/crdroid_settings_navigation.xml
+++ b/res/xml/crdroid_settings_navigation.xml
@@ -39,6 +39,36 @@
         android:dependency="navbar_visibility" />
 
     <PreferenceCategory
+        android:key="navbar_layout_category"
+        android:title="@string/navbar_layout_category_title"
+        android:dependency="navbar_visibility">
+
+        <lineageos.preference.LineageSystemSettingSwitchPreference
+            android:key="navigation_bar_menu_arrow_keys"
+            android:icon="@drawable/ic_arrow_keys"
+            android:title="@string/navbar_arrow_keys_title"
+            android:summary="@string/navbar_arrow_keys_summary"
+            android:defaultValue="false" />
+
+        <com.crdroid.settings.preferences.SecureSettingListPreference
+            android:key="navbar_layout_views"
+            android:icon="@drawable/ic_navbar_layout"
+            android:title="@string/navbar_layout_title"
+            android:summary="%s"
+            android:entries="@array/navbar_layout_entries"
+            android:entryValues="@array/navbar_layout_values"
+            android:defaultValue="default" />
+
+        <com.crdroid.settings.preferences.SecureSettingSwitchPreference
+            android:key="navbar_inverse_layout"
+            android:icon="@drawable/ic_navbar_layout"
+            android:title="@string/navbar_invert_layout_title"
+            android:summary="@string/navbar_invert_layout_summary"
+            android:defaultValue="false" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:key="navbar_actions_category"
         android:title="@string/navbar_actions_category_title"
         android:dependency="navbar_visibility">


### PR DESCRIPTION
Restores the following Navigation Bar options to Matrixx Settings (Matrixx Settings > Navigation) that were previously included.

1. **Show Arrow Keys While Typing**
2. **Invert Layout**
3. **Navigation Bar Layouts**:
Normal
Compact
Expanded
Left-Leaning
Right-Leaning

All necessary settings arrays/keys/values still exist in source and these settings can currently be changed via terminal on Matrixx v10.5.3